### PR TITLE
Replacing /development/ with /master/ in github URLs

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -580,7 +580,7 @@ GEM
     sortable-table (0.1.1)
       actionpack (>= 3.0.0)
       activesupport (>= 3.0.0)
-    sprockets (3.7.1)
+    sprockets (3.7.2)
       concurrent-ruby (~> 1.0)
       rack (> 1, < 3)
     sprockets-rails (3.2.1)

--- a/README.md
+++ b/README.md
@@ -17,7 +17,7 @@ of California’s [Merritt](https://merritt.cdlib.org/) repository service.
 ### Installation
 
 See
-[Dash2 Installation](https://github.com/CDLUC3/dashv2/blob/development/documentation/dash2_install.md)
+[Dash2 Installation](https://github.com/CDLUC3/dashv2/blob/master/documentation/dash2_install.md)
 for installation notes.
 
 ### Quick Cheat Sheet

--- a/app/views/layouts/_about.html.md
+++ b/app/views/layouts/_about.html.md
@@ -15,7 +15,7 @@ There are currently ten live instances of Dash:
 - [UC Press](https://dash.ucpress.edu/)
 - [ONEshare](https://oneshare.cdlib.org/) (in partnership with [DataONE](http://dataone.org/))
 
-For information about Submission to Dash check out our [guidance here](https://github.com/CDLUC3/dashv2/blob/development/app/views/layouts/_help.html.md)
+For information about Submission to Dash check out our [guidance here](https://github.com/CDLUC3/dashv2/blob/master/app/views/layouts/_help.html.md)
 
 
 ## Architecture and Implementation

--- a/app/views/layouts/_help.html.md
+++ b/app/views/layouts/_help.html.md
@@ -6,7 +6,7 @@ We have some general reminders and suggestions for publishing your data with Das
 - It is your responsibility to ensure your data are being shared responsibly and ethically. Please be careful of sharing sensitive data and ensure you are complying with institutional and governmental regulations
 - When preparing your complete version of a dataset, remember to collate all relevant explantory documents and metadata. This includes relevant documentation necessary for the re-use and replication of your dataset (e.g., readme.txt files, formal metadata records, or other critical information, etc.)
 
-Dash has a REST API that allows for download and submission of data. Check out our [documentation](https://dash.ucop.edu/api/docs/index.html) as well as our [How-To Guide](https://github.com/CDLUC3/stash/blob/development/stash_api/basic_submission.md)
+Dash has a REST API that allows for download and submission of data. Check out our [documentation](https://dash.ucop.edu/api/docs/index.html) as well as our [How-To Guide](https://github.com/CDLUC3/stash/blob/master/stash_api/basic_submission.md)
 
 
 ## Metadata

--- a/documentation/dash2_install.md
+++ b/documentation/dash2_install.md
@@ -216,7 +216,7 @@ We have enabled submission to a SWORD-enabled Merritt repository, but have only 
 
 ### Repository and identifier service configuration
 
-The Stash platform requires an implementation of the [Stash::Repo](https://github.com/CDLUC3/stash_engine/tree/development/lib/stash/repo)
+The Stash platform requires an implementation of the [Stash::Repo](https://github.com/CDLUC3/stash/tree/master/lib/stash/repo)
 API for identifier assignment and submission to repositories.
 
 Dash2 uses CDL's EZID service for identifier assignment and stores datasets in the [Merritt](https://merritt.cdlib.org/) repository.

--- a/documentation/documentation_dump.md
+++ b/documentation/documentation_dump.md
@@ -34,7 +34,7 @@ Our demo instance of Dash is available at [https://dashdemo.ucop.edu](https://da
 
 * Operations information (private) [https://confluence.ucop.edu/display/UC3/Stash+Operations](https://confluence.ucop.edu/display/UC3/Stash+Operations) 
 
-* API documentation: [https://github.com/CDLUC3/stash/blob/development/stash_api/basic_submission.md](https://github.com/CDLUC3/stash/blob/development/stash_api/basic_submission.md) and [https://dash.ucop.edu/api/docs/](https://dash.ucop.edu/api/docs/) 
+* API documentation: [https://github.com/CDLUC3/stash/blob/master/stash_api/basic_submission.md](https://github.com/CDLUC3/stash/blob/master/stash_api/basic_submission.md) and [https://dash.ucop.edu/api/docs/](https://dash.ucop.edu/api/docs/) 
 
 * A database [Entity-Relationship diagram](other_files/dash_er_2018-06.pdf).  
 
@@ -44,7 +44,7 @@ Our demo instance of Dash is available at [https://dashdemo.ucop.edu](https://da
 
 * [Dataset submission flow](submission_flow.md), one of our longest and more complicated flows.  (Login is also somewhat complicated, but people don’t spend a lot of time doing it.)
 
-* The UI Library from the UX team and how to integrate CSS and major UI changes into the Dash application.  [https://github.com/CDLUC3/stash/blob/development/stash_engine/ui-library/README.md](https://github.com/CDLUC3/stash/blob/development/stash_engine/ui-library/README.md)
+* The UI Library from the UX team and how to integrate CSS and major UI changes into the Dash application.  [https://github.com/CDLUC3/stash/blob/master/stash_engine/ui-library/README.md](https://github.com/CDLUC3/stash/blob/master/stash_engine/ui-library/README.md)
 
 * Please see [how to set up and run tests locally](local_testing_setup.md) so you can add tests and run current tests to be sure nothing breaks.
 

--- a/documentation/how_to_contribute.md
+++ b/documentation/how_to_contribute.md
@@ -18,7 +18,7 @@ The basic flow of this model would be to:
 # for example
 git remote add upstream https://github.com/CDLUC3/dashv2.git
 git fetch upstream
-git merge upstream/development
+git merge upstream/master
 ```
   
   - Make all needed changes and push them to your fork.
@@ -46,7 +46,7 @@ Changes to database schemas or model classes
 
 Changes to views
 
-- Did you add major UI changes such as new layouts, css styles or images to the [UI library](https://github.com/CDLUC3/stash/tree/development/stash_engine/ui-library) ?
+- Did you add major UI changes such as new layouts, css styles or images to the [UI library](https://github.com/CDLUC3/stash/tree/master/stash_engine/ui-library) ?
 - Are feature tests (browser automation) added or modified in order to test the change?
 
 

--- a/spec/config/solr/conf/TODO.md
+++ b/spec/config/solr/conf/TODO.md
@@ -1,3 +1,3 @@
 # TO DO
 
-- Move this to [stash_discovery](https://github.com/CDLUC3/stash/tree/development/stash_discovery)
+- Move this to [stash_discovery](https://github.com/CDLUC3/stash/tree/master/stash_discovery)


### PR DESCRIPTION
AARGH.  I have a ghost pull request I can't get rid of. When I tried to close it, it closed this one instead.

development has been removed and fixing updated urls to master.

Sorry for the last request.  I had a problem with the wrong branch checked out for the pull request.